### PR TITLE
make attaching of remote resources more robust in Sharing feature

### DIFF
--- a/java/src/androidnative/Share.java
+++ b/java/src/androidnative/Share.java
@@ -190,7 +190,7 @@ public class Share {
             Activity activity = org.qtproject.qt5.android.QtNative.activity();
 
             File baseDir=activity.getExternalFilesDir(null);
-            String fileName = Uri.parse(urlString).getLastPathSegment();
+            String fileName = Uri.parse(Uri.decode(urlString)).getLastPathSegment();
 
             File localFile = null ;
 


### PR DESCRIPTION
	(1) In case the url contains elements that has encoded path
      separators , the filename extracted from url may contain
      embedded fileseparator charactor. A safer approach is to
      decode the input urlString and then determine the last
      element in the path for using as filename.